### PR TITLE
Apim 2140 gen http signature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,22 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.1</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.generatehttpsignature.GenerateHttpSignaturePolicy
 type=policy
 category=security
 icon=generate-http-signature.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,10 +1,11 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:generatehttpsignature:configuration:GenerateHttpSignaturePolicyConfiguration",
+  "additionalProperties": false,
   "properties": {
     "scheme" : {
       "title": "Scheme",
-      "description": "Signature Scheme",
+      "description": "Signature Scheme.",
       "type" : "string",
       "default": "AUTHORIZATION",
       "enum" : [
@@ -16,6 +17,12 @@
         "titleMap": {
           "AUTHORIZATION": "\"Signature\" HTTP Authentication Scheme",
           "SIGNATURE": "\"Signature\" HTTP Header"
+        }
+      },
+      "gioConfig": {
+        "banner": {
+          "title": "Signature Scheme.",
+          "text": "<ul><li>AUTHORIZATION: \"Signature\" HTTP Authentication Scheme</li><li>SIGNATURE: \"Signature\" HTTP Header</li></ul>"
         }
       }
     },
@@ -65,7 +72,7 @@
     "validityDuration": {
       "title": "Validity duration",
       "default": 3,
-      "description": "Signature's maximum validation duration in seconds",
+      "description": "Signature's maximum validation duration in seconds.",
       "type": "integer",
       "minimum": 1,
       "x-schema-form": {
@@ -76,6 +83,12 @@
             }
           }
         ]
+      },
+      "gioConfig": {
+        "banner": {
+          "title": "Validity duration",
+          "text": "Signature's maximum validation duration in seconds. (Used only if the expires header is included in the signature.)"
+        }
       }
     }
   },


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

* upgrade circle ci config
* upgrade gravitee-parent
* update schema form and define execution phase in the plugin.properties
* update renovate config
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-apim-2140-gen-http-signature-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-http-signature/1.2.0-apim-2140-gen-http-signature-SNAPSHOT/gravitee-policy-generate-http-signature-1.2.0-apim-2140-gen-http-signature-SNAPSHOT.zip)
  <!-- Version placeholder end -->
