### PR TITLE
fix: update policy description

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default
-*       @gravitee-io/apim @gravitee-io/archi
+*       @gravitee-io/apim

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Issue**
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/APIM-XXXX
 
 **Description**
 

--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,14 @@ You can use:
 
 NOTE: Current version of the policy does not support *Digest*, *(request-target)*, *Host* and *Path* header.
 
+== Compatibility with APIM
+
+|===
+| Plugin version | APIM version
+
+| Up to 1.x                   | All
+|===
+
 == Configuration
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <version>1.2.0</version>
 
     <name>Gravitee.io APIM - Policy - Generate HTTP Signature</name>
-    <description>Description of the Generate HTTP Signature Gravitee Policy</description>
+    <description>Generate HTTP Signature</description>
 
     <parent>
         <groupId>io.gravitee</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2187
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-update-description-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-http-signature/1.2.1-update-description-SNAPSHOT/gravitee-policy-generate-http-signature-1.2.1-update-description-SNAPSHOT.zip)
  <!-- Version placeholder end -->
