### PR TITLE
Change `expires` to `int` to match RFC

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Signatures.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signatures.java
@@ -82,8 +82,8 @@ public enum Signatures {
                 if (signatureExpiryTime == null) {
                     throw new InvalidExpiresFieldException("(expires) field requested but signature expiration time is not set");
                 }
-                final double expires = signatureExpiryTime / 1000.0;
-                list.add(key + ": " + String.format("%.3f", expires));
+                final int expires = (int) (signatureExpiryTime / 1000);
+                list.add(key + ": " + expires);
             } else {
                 final String value = headers.get(key);
                 if (value == null) throw new MissingRequiredHeaderException(key);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1360
https://github.com/gravitee-io/issues/issues/8972

**Description**

Change `expires` to `int` to match RFC
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.2-APIM-1360-fix-expires-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-http-signature/1.2.2-APIM-1360-fix-expires-SNAPSHOT/gravitee-policy-generate-http-signature-1.2.2-APIM-1360-fix-expires-SNAPSHOT.zip)
  <!-- Version placeholder end -->
