### PR TITLE
bugfix(EXT-40): fixing conflicting method names

### DIFF
--- a/src/main/java/io/gravitee/policy/generatehttpsignature/GenerateHttpSignaturePolicy.java
+++ b/src/main/java/io/gravitee/policy/generatehttpsignature/GenerateHttpSignaturePolicy.java
@@ -291,7 +291,7 @@ public class GenerateHttpSignaturePolicy extends GenerateHttpSignaturePolicyV3 i
         );
         Signer signer = super.buildSigner(signatureFromConfiguration, () -> secret);
         logger.debug("Method and URI: {} {}", method, uri);
-        Signature signature = signer.sign(method, uri, headers.toSingleValueMap(), payload);
+        Signature signature = signer.signWithPayload(method, uri, headers.toSingleValueMap(), payload);
         setSignatureHeader(headers, configuration.targetSignatureHeader(), signature);
     }
 

--- a/src/main/java/io/gravitee/policy/generatehttpsignature/v3/GenerateHttpSignaturePolicyV3.java
+++ b/src/main/java/io/gravitee/policy/generatehttpsignature/v3/GenerateHttpSignaturePolicyV3.java
@@ -89,7 +89,13 @@ public class GenerateHttpSignaturePolicyV3 {
         final Signature signature;
 
         try {
-            signature = signer.sign(request.method().name().toLowerCase(), request.path(), requestHeaders.toSingleValueMap(), null);
+            signature = signer.sign(
+                request.method().name().toLowerCase(),
+                request.path(),
+                requestHeaders.toSingleValueMap(),
+                request.timestamp(),
+                request.timestamp() + configuration.validityDuration() * 1000L
+            );
         } catch (IOException e) {
             final String errorMessage = String.format("%s %s", ERROR_MESSAGE, e.getMessage());
             logger.warn(errorMessage);

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -137,10 +137,9 @@ public class Signature {
         final String signingAlgorithm,
         final String algorithm,
         final AlgorithmParameterSpec parameterSpec,
-        final List<String> headers,
-        final boolean signHeaders
+        final List<String> headers
     ) {
-        this(keyId, getSigningAlgorithm(signingAlgorithm), getAlgorithm(algorithm), parameterSpec, null, headers, signHeaders);
+        this(keyId, getSigningAlgorithm(signingAlgorithm), getAlgorithm(algorithm), parameterSpec, null, headers);
     }
 
     private static Algorithm getAlgorithm(final String algorithm) {
@@ -154,29 +153,23 @@ public class Signature {
     }
 
     @Deprecated
-    public Signature(final String keyId, final String algorithm, final String signature, boolean signHeaders, final String... headers) {
-        this(keyId, getAlgorithm(algorithm), signature, signHeaders, headers);
+    public Signature(final String keyId, final String algorithm, final String signature, final String... headers) {
+        this(keyId, getAlgorithm(algorithm), signature, headers);
     }
 
     @Deprecated
-    public Signature(final String keyId, final Algorithm algorithm, final String signature, boolean signHeaders, final String... headers) {
-        this(keyId, algorithm, signature, Arrays.asList(headers), signHeaders);
+    public Signature(final String keyId, final Algorithm algorithm, final String signature, final String... headers) {
+        this(keyId, algorithm, signature, Arrays.asList(headers));
     }
 
     @Deprecated
-    public Signature(final String keyId, final String algorithm, final String signature, final List<String> headers, boolean signHeaders) {
-        this(keyId, getAlgorithm(algorithm), signature, headers, signHeaders);
+    public Signature(final String keyId, final String algorithm, final String signature, final List<String> headers) {
+        this(keyId, getAlgorithm(algorithm), signature, headers);
     }
 
     @Deprecated
-    public Signature(
-        final String keyId,
-        final Algorithm algorithm,
-        final String signature,
-        final List<String> headers,
-        boolean signHeaders
-    ) {
-        this(keyId, null, algorithm, null, signature, headers, null, null, null, signHeaders);
+    public Signature(final String keyId, final Algorithm algorithm, final String signature, final List<String> headers) {
+        this(keyId, null, algorithm, null, signature, headers, null, null, null);
     }
 
     public Signature(
@@ -185,10 +178,20 @@ public class Signature {
         final String algorithm,
         final AlgorithmParameterSpec parameterSpec,
         final String signature,
-        final List<String> headers,
-        boolean signHeaders
+        final List<String> headers
     ) {
-        this(keyId, getSigningAlgorithm(signingAlgorithm), getAlgorithm(algorithm), parameterSpec, signature, headers, signHeaders);
+        this(keyId, getSigningAlgorithm(signingAlgorithm), getAlgorithm(algorithm), parameterSpec, signature, headers);
+    }
+
+    public Signature(
+        final String keyId,
+        final SigningAlgorithm signingAlgorithm,
+        final Algorithm algorithm,
+        final AlgorithmParameterSpec parameterSpec,
+        final String signature,
+        final List<String> headers
+    ) {
+        this(keyId, signingAlgorithm, algorithm, parameterSpec, signature, headers, null);
     }
 
     public Signature(
@@ -198,9 +201,9 @@ public class Signature {
         final AlgorithmParameterSpec parameterSpec,
         final String signature,
         final List<String> headers,
-        boolean signHeaders
+        final Long maxSignatureValidityDuration
     ) {
-        this(keyId, signingAlgorithm, algorithm, parameterSpec, signature, headers, null, signHeaders);
+        this(keyId, signingAlgorithm, algorithm, parameterSpec, signature, headers, maxSignatureValidityDuration, null, null);
     }
 
     public Signature(
@@ -211,9 +214,47 @@ public class Signature {
         final String signature,
         final List<String> headers,
         final Long maxSignatureValidityDuration,
-        boolean signHeaders
+        final Long signatureCreatedTime,
+        final Long signatureExpiresTime
     ) {
-        this(keyId, signingAlgorithm, algorithm, parameterSpec, signature, headers, maxSignatureValidityDuration, null, null, signHeaders);
+        this(
+            keyId,
+            signingAlgorithm,
+            algorithm,
+            parameterSpec,
+            signature,
+            headers,
+            maxSignatureValidityDuration,
+            signatureCreatedTime,
+            signatureExpiresTime,
+            false
+        );
+    }
+
+    public Signature(
+        final String keyId,
+        final String signingAlgorithm,
+        final String algorithm,
+        final AlgorithmParameterSpec parameterSpec,
+        final String signature,
+        final List<String> headers,
+        final Long maxSignatureValidityDuration,
+        final Long signatureCreatedTime,
+        final Long signatureExpiresTime,
+        final boolean signHeaders
+    ) {
+        this(
+            keyId,
+            getSigningAlgorithm(signingAlgorithm),
+            getAlgorithm(algorithm),
+            parameterSpec,
+            signature,
+            headers,
+            maxSignatureValidityDuration,
+            signatureCreatedTime,
+            signatureExpiresTime,
+            signHeaders
+        );
     }
 
     public Signature(

--- a/src/main/java/org/tomitribe/auth/signatures/Signatures.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signatures.java
@@ -51,7 +51,7 @@ public enum Signatures {
         final Long signatureCreationTime,
         final Long signatureExpiryTime
     ) {
-        return createSigningString(required, method, uri, headers, signatureCreationTime, signatureExpiryTime, null);
+        return createSigningStringWithPayload(required, method, uri, headers, signatureCreationTime, signatureExpiryTime, null);
     }
 
     /**
@@ -71,7 +71,7 @@ public enum Signatures {
      * @param signatureExpiryTime The signature expiration time in milliseconds since the epoch.
      * @param payload The payload to be included in the signing string. It is not associated with any header name.
      */
-    public static String createSigningString(
+    public static String createSigningStringWithPayload(
         final List<String> required,
         String method,
         final String uri,

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -75,7 +75,26 @@ public class Signer {
      *
      * @return a Signature object containing the signed message.
      */
-    public Signature sign(
+    public Signature sign(final String method, final String uri, final Map<String, String> headers, Long created, Long expires)
+        throws IOException {
+        return signWithPayload(method, uri, headers, created, expires, null);
+    }
+
+    /**
+     * Create and return a HTTP signature object configured with 'created' and 'expires' values.
+     * Useful if you want to recreate a Signature from configuration to validate another one.
+     *
+     * @param method The HTTP method.
+     * @param uri The path and query of the request target of the message.
+     *            The value must already be encoded exactly as it will be sent in the
+     *            request line of the HTTP message. No URL encoding is performed by this method.
+     * @param headers The HTTP headers.
+     * @param created the created timestamp
+     * @param expires the expires timestamp
+     *
+     * @return a Signature object containing the signed message.
+     */
+    public Signature signWithPayload(
         final String method,
         final String uri,
         final Map<String, String> headers,
@@ -83,7 +102,7 @@ public class Signer {
         Long expires,
         String payload
     ) throws IOException {
-        final String signingString = createSigningString(method, uri, headers, created, expires, payload);
+        final String signingString = createSigningStringWithPayload(method, uri, headers, created, expires, payload);
 
         final byte[] binarySignature = sign.sign(signingString.getBytes("UTF-8"));
 
@@ -116,13 +135,29 @@ public class Signer {
      *
      * @return a Signature object containing the signed message.
      */
-    public Signature sign(final String method, final String uri, final Map<String, String> headers, String payload) throws IOException {
+    public Signature sign(final String method, final String uri, final Map<String, String> headers) throws IOException {
+        return signWithPayload(method, uri, headers, null, null, null);
+    }
+
+    /**
+     * Create and return a HTTP signature object.
+     *
+     * @param method The HTTP method.
+     * @param uri The path and query of the request target of the message.
+     *            The value must already be encoded exactly as it will be sent in the
+     *            request line of the HTTP message. No URL encoding is performed by this method.
+     * @param headers The HTTP headers.
+     *
+     * @return a Signature object containing the signed message.
+     */
+    public Signature signWithPayload(final String method, final String uri, final Map<String, String> headers, String payload)
+        throws IOException {
         final long created = System.currentTimeMillis();
         Long expires = signature.getSignatureMaxValidityMilliseconds();
         if (expires != null) {
             expires += created;
         }
-        return sign(method, uri, headers, created, expires, payload);
+        return signWithPayload(method, uri, headers, created, expires, payload);
     }
 
     /**
@@ -162,7 +197,7 @@ public class Signer {
      * @return The signing string.
      * @throws IOException when an exception occurs while creating the signing string.
      */
-    public String createSigningString(
+    public String createSigningStringWithPayload(
         final String method,
         final String uri,
         final Map<String, String> headers,
@@ -170,7 +205,7 @@ public class Signer {
         final Long expires,
         final String payload
     ) throws IOException {
-        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, created, expires, payload);
+        return Signatures.createSigningStringWithPayload(signature.getHeaders(), method, uri, headers, created, expires, payload);
     }
 
     /**

--- a/src/test/java/io/gravitee/policy/generatehttpsignature/GenerateHttpSignaturePolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/generatehttpsignature/GenerateHttpSignaturePolicyIntegrationTest.java
@@ -586,7 +586,7 @@ class GenerateHttpSignaturePolicyIntegrationTest {
             );
             final Key key = new SecretKeySpec(secret.getBytes(), signatureFromConfiguration.getAlgorithm().getJvmName());
             Signer signer = new Signer(key, signatureFromConfiguration);
-            Signature signature = signer.sign("method", "uri", httpHeaders.toSingleValueMap(), payload);
+            Signature signature = signer.signWithPayload("method", "uri", httpHeaders.toSingleValueMap(), payload);
             return signature.toString().substring(10); // Remove the "Signature " part of the signature;
         } catch (Exception e) {
             throw new RuntimeException("Failed to generate expected signature", e);

--- a/src/test/java/io/gravitee/policy/generatehttpsignature/v3/GenerateHttpSignaturePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/generatehttpsignature/v3/GenerateHttpSignaturePolicyTest.java
@@ -102,7 +102,7 @@ class GenerateHttpSignaturePolicyTest {
         final Signer signer = mock(Signer.class);
 
         doReturn(signer).when(spy).buildSigner(any(), any());
-        when(signer.sign(any(), any(), any(), any())).thenThrow(new IOException("exception-message"));
+        when(signer.sign(any(), any(), any(), any(), any())).thenThrow(new IOException("exception-message"));
 
         final Metrics metrics = Metrics.on(System.currentTimeMillis()).build();
 

--- a/src/test/java/io/gravitee/policy/generatehttpsignature/v3/GenerateHttpSignaturePolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/generatehttpsignature/v3/GenerateHttpSignaturePolicyV3IntegrationTest.java
@@ -122,7 +122,7 @@ class GenerateHttpSignaturePolicyV3IntegrationTest
                 return request.rxSend();
             })
             .test()
-            .awaitDone(5, SECONDS)
+            .awaitDone(2, SECONDS)
             .assertComplete()
             .assertNoErrors();
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/EXT-40

**Description**

Fixed the conflicting method names in the Signing classes, found during tests.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-bugfix-EXT-40-bugfix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-http-signature/1.5.1-bugfix-EXT-40-bugfix-SNAPSHOT/gravitee-policy-generate-http-signature-1.5.1-bugfix-EXT-40-bugfix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
